### PR TITLE
[#147170295] Fix error on send_alert method. Convert timedelta to sec…

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -111,7 +111,7 @@ class Check(models.Model):
         channels = Priority.get_priority_channels(self)
         while self.nag_time and (self.status == "down"):
             errors = self._alert(channels, errors)
-            time.sleep(self.nag_time)
+            time.sleep(self.nag_time.total_seconds())
         else:
             errors = self._alert(channels, errors)
         return errors


### PR DESCRIPTION
Fixed an error on the send alert method. The nag feature now sends alerts in intervals set by the user until the status changes.